### PR TITLE
Three config files

### DIFF
--- a/clients/new_project/pankosmia_metadata.json
+++ b/clients/new_project/pankosmia_metadata.json
@@ -2,7 +2,7 @@
   "id": "core-new-project",
   "require": {
     "net": false,
-    "debug": true
+    "debug": false
   },
   "i18n": {
     "title": {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -132,6 +132,13 @@ fn os_slash_str() -> &'static str {
     }
 }
 
+fn os_quoted_slash_str() -> &'static str {
+    match env::consts::OS {
+        "windows" => "\\\\",
+        _ => "/"
+    }
+}
+
 fn forbidden_path_strings() -> Vec<String> {
     Vec::from([
         "..".to_string(),
@@ -1499,7 +1506,7 @@ fn rocket() -> Rocket<Build> {
             let app_setup_json_string = match fs::read_to_string(app_setup_template_path) {
                 Ok(s) => s
                     .replace("%%STUBCLIENTSDIR%%", relative!("../clients"))
-                    .replace("%%OSSLASH%%", os_slash_str()),
+                    .replace("%%OSSLASH%%", os_quoted_slash_str()),
                 Err(e) => {
                     println!("Could not read app_setup file '{}': {}", app_setup_template_path, e);
                     exit(1);
@@ -1524,7 +1531,7 @@ fn rocket() -> Rocket<Build> {
             let user_settings_json_string = match fs::read_to_string(&user_settings_template_path) {
                 Ok(s) => s
                     .replace("%%WORKINGDIR%%", &working_dir_path)
-                    .replace("%%OSSLASH%%", os_slash_str()),
+                    .replace("%%OSSLASH%%", os_quoted_slash_str()),
                 Err(e) => {
                     println!("Could not read user settings template file '{}': {}", user_settings_template_path, e);
                     exit(1);
@@ -1549,7 +1556,7 @@ fn rocket() -> Rocket<Build> {
             let app_state_json_string = match fs::read_to_string(&app_state_template_path) {
                 Ok(s) => s
                     .replace("%%WORKINGDIR%%", &working_dir_path)
-                    .replace("%%OSSLASH%%", os_slash_str()),
+                    .replace("%%OSSLASH%%", os_quoted_slash_str()),
                 Err(e) => {
                     println!("Could not read app state template file '{}': {}", user_settings_template_path, e);
                     exit(1);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -132,20 +132,19 @@ fn os_slash_str() -> &'static str {
     }
 }
 
-fn os_quoted_slash_str() -> &'static str {
+/*fn os_quoted_slash_str() -> &'static str {
     match env::consts::OS {
         "windows" => "\\\\",
         _ => "/"
     }
 }
+ */
 
 fn maybe_os_quoted_path_str(s: String) -> String {
-    let quoted = match env::consts::OS {
+    match env::consts::OS {
         "windows" => s.replace("\\", "\\\\").replace("/", "\\\\"),
         _ => s
-    };
-    println!("{}", quoted.clone());
-    quoted
+    }
 }
 
 fn forbidden_path_strings() -> Vec<String> {
@@ -1511,13 +1510,11 @@ fn rocket() -> Rocket<Build> {
                     exit(1);
                 }
             };
-            // Copy app_setuo file to working dir
+            // Copy app_setup file to working dir
             let app_setup_template_path = relative!("./templates/app_setup.json");
             let app_setup_json_string = match fs::read_to_string(app_setup_template_path) {
                 Ok(s) => maybe_os_quoted_path_str(
-                    s
-                        .replace("%%STUBCLIENTSDIR%%", relative!("../clients"))
-                        .replace("%%OSSLASH%%", os_quoted_slash_str())
+                    s.replace("%%STUBCLIENTSDIR%%", relative!("../clients"))
                 ),
                 Err(e) => {
                     println!("Could not read app_setup file '{}': {}", app_setup_template_path, e);
@@ -1541,9 +1538,9 @@ fn rocket() -> Rocket<Build> {
             // Copy user_settings file to working dir
             let user_settings_template_path = relative!("./templates/user_settings.json");
             let user_settings_json_string = match fs::read_to_string(&user_settings_template_path) {
-                Ok(s) => s
-                    .replace("%%WORKINGDIR%%", &working_dir_path)
-                    .replace("%%OSSLASH%%", os_quoted_slash_str()),
+                Ok(s) => maybe_os_quoted_path_str(
+                    s.replace("%%WORKINGDIR%%", &working_dir_path)
+                ),
                 Err(e) => {
                     println!("Could not read user settings template file '{}': {}", user_settings_template_path, e);
                     exit(1);
@@ -1566,9 +1563,8 @@ fn rocket() -> Rocket<Build> {
             // Copy app_state file to working dir
             let app_state_template_path = relative!("./templates/app_state.json");
             let app_state_json_string = match fs::read_to_string(&app_state_template_path) {
-                Ok(s) => s
-                    .replace("%%WORKINGDIR%%", &working_dir_path)
-                    .replace("%%OSSLASH%%", os_quoted_slash_str()),
+                Ok(s) => maybe_os_quoted_path_str(
+                    s.replace("%%WORKINGDIR%%", &working_dir_path)),
                 Err(e) => {
                     println!("Could not read app state template file '{}': {}", user_settings_template_path, e);
                     exit(1);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1497,7 +1497,9 @@ fn rocket() -> Rocket<Build> {
             // Copy app_setuo file to working dir
             let app_setup_template_path = relative!("./templates/app_setup.json");
             let app_setup_json_string = match fs::read_to_string(app_setup_template_path) {
-                Ok(s) => s.replace("%%STUBCLIENTSDIR%%", relative!("../clients")),
+                Ok(s) => s
+                    .replace("%%STUBCLIENTSDIR%%", relative!("../clients"))
+                    .replace("%%OSSLASH%%", os_slash_str()),
                 Err(e) => {
                     println!("Could not read app_setup file '{}': {}", app_setup_template_path, e);
                     exit(1);
@@ -1520,7 +1522,9 @@ fn rocket() -> Rocket<Build> {
             // Copy user_settings file to working dir
             let user_settings_template_path = relative!("./templates/user_settings.json");
             let user_settings_json_string = match fs::read_to_string(&user_settings_template_path) {
-                Ok(s) => s.replace("%%WORKINGDIR%%", &working_dir_path),
+                Ok(s) => s
+                    .replace("%%WORKINGDIR%%", &working_dir_path)
+                    .replace("%%OSSLASH%%", os_slash_str()),
                 Err(e) => {
                     println!("Could not read user settings template file '{}': {}", user_settings_template_path, e);
                     exit(1);
@@ -1543,7 +1547,9 @@ fn rocket() -> Rocket<Build> {
             // Copy app_state file to working dir
             let app_state_template_path = relative!("./templates/app_state.json");
             let app_state_json_string = match fs::read_to_string(&app_state_template_path) {
-                Ok(s) => s.replace("%%WORKINGDIR%%", &working_dir_path),
+                Ok(s) => s
+                    .replace("%%WORKINGDIR%%", &working_dir_path)
+                    .replace("%%OSSLASH%%", os_slash_str()),
                 Err(e) => {
                     println!("Could not read app state template file '{}': {}", user_settings_template_path, e);
                     exit(1);
@@ -1643,7 +1649,7 @@ fn rocket() -> Rocket<Build> {
             }
         }
     };
-    // Merge client config into into settings JSON
+    // Merge client config into settings JSON
     let mut clients_merged_array: Vec<Value> = Vec::new();
     for client_record in app_setup_json["clients"].as_array().unwrap().iter() {
         // Get requires from metadata

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -141,7 +141,7 @@ fn os_quoted_slash_str() -> &'static str {
 
 fn maybe_os_quoted_path_str(s: String) -> String {
     match env::consts::OS {
-        "windows" => s.replace("/", "\\\\"),
+        "windows" => s.replace("\\", "\\\\").replace("/", "\\\\"),
         _ => s
     }
 }
@@ -1479,6 +1479,7 @@ type Clients = Mutex<Vec<Client>>;
 
 #[rocket::launch]
 fn rocket() -> Rocket<Build> {
+    println!("OS = '{}'", env::consts::OS);
     // Set up managed state;
     let msg_queue = MsgQueue::new(Mutex::new(VecDeque::new()));
     // Get settings path, default to well-known homedir location

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1477,9 +1477,9 @@ fn rocket() -> Rocket<Build> {
     if args.len() == 2 {
         // Do not auto-make at non-default location.
         working_dir_path = args[1].clone();
-        app_setup_path = format!("{}/app_setup.json", working_dir_path);
-        app_state_path = format!("{}/app_state.json", working_dir_path);
-        user_settings_path = format!("{}/user_settings.json", working_dir_path);
+        app_setup_path = format!("{}{}app_setup.json", working_dir_path, os_slash_str());
+        app_state_path = format!("{}{}app_state.json", working_dir_path, os_slash_str());
+        user_settings_path = format!("{}{}user_settings.json", working_dir_path, os_slash_str());
     } else {
         // Well-known location.
         // If directory doesn't exist make one.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -140,10 +140,12 @@ fn os_quoted_slash_str() -> &'static str {
 }
 
 fn maybe_os_quoted_path_str(s: String) -> String {
-    match env::consts::OS {
+    let quoted = match env::consts::OS {
         "windows" => s.replace("\\", "\\\\").replace("/", "\\\\"),
         _ => s
-    }
+    };
+    println!("{}", quoted.clone());
+    quoted
 }
 
 fn forbidden_path_strings() -> Vec<String> {
@@ -1512,9 +1514,11 @@ fn rocket() -> Rocket<Build> {
             // Copy app_setuo file to working dir
             let app_setup_template_path = relative!("./templates/app_setup.json");
             let app_setup_json_string = match fs::read_to_string(app_setup_template_path) {
-                Ok(s) => maybe_os_quoted_path_str(s)
-                    .replace("%%STUBCLIENTSDIR%%", relative!("../clients"))
-                    .replace("%%OSSLASH%%", os_quoted_slash_str()),
+                Ok(s) => maybe_os_quoted_path_str(
+                    s
+                        .replace("%%STUBCLIENTSDIR%%", relative!("../clients"))
+                        .replace("%%OSSLASH%%", os_quoted_slash_str())
+                ),
                 Err(e) => {
                     println!("Could not read app_setup file '{}': {}", app_setup_template_path, e);
                     exit(1);
@@ -1537,7 +1541,7 @@ fn rocket() -> Rocket<Build> {
             // Copy user_settings file to working dir
             let user_settings_template_path = relative!("./templates/user_settings.json");
             let user_settings_json_string = match fs::read_to_string(&user_settings_template_path) {
-                Ok(s) => maybe_os_quoted_path_str(s)
+                Ok(s) => s
                     .replace("%%WORKINGDIR%%", &working_dir_path)
                     .replace("%%OSSLASH%%", os_quoted_slash_str()),
                 Err(e) => {
@@ -1562,7 +1566,7 @@ fn rocket() -> Rocket<Build> {
             // Copy app_state file to working dir
             let app_state_template_path = relative!("./templates/app_state.json");
             let app_state_json_string = match fs::read_to_string(&app_state_template_path) {
-                Ok(s) => maybe_os_quoted_path_str(s)
+                Ok(s) => s
                     .replace("%%WORKINGDIR%%", &working_dir_path)
                     .replace("%%OSSLASH%%", os_quoted_slash_str()),
                 Err(e) => {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -139,6 +139,13 @@ fn os_quoted_slash_str() -> &'static str {
     }
 }
 
+fn maybe_os_quoted_path_str(s: String) -> String {
+    match env::consts::OS {
+        "windows" => s.replace("/", "\\\\"),
+        _ => s
+    }
+}
+
 fn forbidden_path_strings() -> Vec<String> {
     Vec::from([
         "..".to_string(),
@@ -1504,7 +1511,7 @@ fn rocket() -> Rocket<Build> {
             // Copy app_setuo file to working dir
             let app_setup_template_path = relative!("./templates/app_setup.json");
             let app_setup_json_string = match fs::read_to_string(app_setup_template_path) {
-                Ok(s) => s
+                Ok(s) => maybe_os_quoted_path_str(s)
                     .replace("%%STUBCLIENTSDIR%%", relative!("../clients"))
                     .replace("%%OSSLASH%%", os_quoted_slash_str()),
                 Err(e) => {
@@ -1529,7 +1536,7 @@ fn rocket() -> Rocket<Build> {
             // Copy user_settings file to working dir
             let user_settings_template_path = relative!("./templates/user_settings.json");
             let user_settings_json_string = match fs::read_to_string(&user_settings_template_path) {
-                Ok(s) => s
+                Ok(s) => maybe_os_quoted_path_str(s)
                     .replace("%%WORKINGDIR%%", &working_dir_path)
                     .replace("%%OSSLASH%%", os_quoted_slash_str()),
                 Err(e) => {
@@ -1554,7 +1561,7 @@ fn rocket() -> Rocket<Build> {
             // Copy app_state file to working dir
             let app_state_template_path = relative!("./templates/app_state.json");
             let app_state_json_string = match fs::read_to_string(&app_state_template_path) {
-                Ok(s) => s
+                Ok(s) => maybe_os_quoted_path_str(s)
                     .replace("%%WORKINGDIR%%", &working_dir_path)
                     .replace("%%OSSLASH%%", os_quoted_slash_str()),
                 Err(e) => {

--- a/server/templates/app_setup.json
+++ b/server/templates/app_setup.json
@@ -1,20 +1,20 @@
 {
   "clients": [
     {
-      "path": "%%STUBCLIENTSDIR%%/dashboard"
+      "path": "%%STUBCLIENTSDIR%%%%OSSLASH%%dashboard"
     },
     {
       "exclude_from_menu": true,
-      "path": "%%STUBCLIENTSDIR%%/settings"
+      "path": "%%STUBCLIENTSDIR%%%%OSSLASH%%settings"
     },
     {
-      "path": "%%STUBCLIENTSDIR%%/new_project"
+      "path": "%%STUBCLIENTSDIR%%%%OSSLASH%%new_project"
     },
     {
-      "path": "%%STUBCLIENTSDIR%%/download"
+      "path": "%%STUBCLIENTSDIR%%%%OSSLASH%%download"
     },
     {
-      "path": "%%STUBCLIENTSDIR%%/local_projects"
+      "path": "%%STUBCLIENTSDIR%%%%OSSLASH%%local_projects"
     }
   ]
 }

--- a/server/templates/app_setup.json
+++ b/server/templates/app_setup.json
@@ -1,0 +1,20 @@
+{
+  "clients": [
+    {
+      "path": "%%STUBCLIENTSDIR%%/dashboard"
+    },
+    {
+      "exclude_from_menu": true,
+      "path": "%%STUBCLIENTSDIR%%/settings"
+    },
+    {
+      "path": "%%STUBCLIENTSDIR%%/new_project"
+    },
+    {
+      "path": "%%STUBCLIENTSDIR%%/download"
+    },
+    {
+      "path": "%%STUBCLIENTSDIR%%/local_projects"
+    }
+  ]
+}

--- a/server/templates/app_setup.json
+++ b/server/templates/app_setup.json
@@ -1,20 +1,20 @@
 {
   "clients": [
     {
-      "path": "%%STUBCLIENTSDIR%%%%OSSLASH%%dashboard"
+      "path": "%%STUBCLIENTSDIR%%/dashboard"
     },
     {
       "exclude_from_menu": true,
-      "path": "%%STUBCLIENTSDIR%%%%OSSLASH%%settings"
+      "path": "%%STUBCLIENTSDIR%%/settings"
     },
     {
-      "path": "%%STUBCLIENTSDIR%%%%OSSLASH%%new_project"
+      "path": "%%STUBCLIENTSDIR%%/new_project"
     },
     {
-      "path": "%%STUBCLIENTSDIR%%%%OSSLASH%%download"
+      "path": "%%STUBCLIENTSDIR%%/download"
     },
     {
-      "path": "%%STUBCLIENTSDIR%%%%OSSLASH%%local_projects"
+      "path": "%%STUBCLIENTSDIR%%/local_projects"
     }
   ]
 }

--- a/server/templates/app_state.json
+++ b/server/templates/app_state.json
@@ -1,0 +1,7 @@
+{
+  "bcv": {
+    "book_code": "TIT",
+    "chapter": 1,
+    "verse": 1
+  }
+}

--- a/server/templates/user_settings.json
+++ b/server/templates/user_settings.json
@@ -3,11 +3,6 @@
     "en"
   ],
   "repo_dir": "%%WORKINGDIR%%/repos",
-  "bcv": {
-    "book_code": "TIT",
-    "chapter": 2,
-    "verse": 4
-  },
   "typography": {
     "direction": "ltr",
     "font_set": "gentiumPlus",

--- a/server/templates/user_settings.json
+++ b/server/templates/user_settings.json
@@ -1,0 +1,16 @@
+{
+  "languages": [
+    "en"
+  ],
+  "repo_dir": "%%WORKINGDIR%%/repos",
+  "bcv": {
+    "book_code": "TIT",
+    "chapter": 2,
+    "verse": 4
+  },
+  "typography": {
+    "direction": "ltr",
+    "font_set": "gentiumPlus",
+    "size": "medium"
+  }
+}

--- a/server/templates/user_settings.json
+++ b/server/templates/user_settings.json
@@ -2,7 +2,7 @@
   "languages": [
     "en"
   ],
-  "repo_dir": "%%WORKINGDIR%%/repos",
+  "repo_dir": "%%WORKINGDIR%%%%OSSLASH%%repos",
   "typography": {
     "direction": "ltr",
     "font_set": "gentiumPlus",

--- a/server/templates/user_settings.json
+++ b/server/templates/user_settings.json
@@ -2,7 +2,7 @@
   "languages": [
     "en"
   ],
-  "repo_dir": "%%WORKINGDIR%%%%OSSLASH%%repos",
+  "repo_dir": "%%WORKINGDIR%%/repos",
   "typography": {
     "direction": "ltr",
     "font_set": "gentiumPlus",


### PR DESCRIPTION
This PR anticipates the Tauri build part of the project. Until now all the config info was in one file. We now have
- app_setup.json for build-time decisions, eg which clients to bundle
- user_settings.json for things the user explicitly chooses, eg languages, and which will be editable via the UI
- app_state.json for "where did we get to" data, eg the last BCV, the workspace layout

The code for this is somewhat repetitive - I'll fix that when the server has its own repo. The files are created from templates with placeholders, which clears the way for per-dev-team templates in the future.

You need to delete the old workspace. (I'm not trying to fix existing workspace directories.) Seems to work for me both without and with a (current) workspace.